### PR TITLE
IS-702: Fix validation check in register prep

### DIFF
--- a/preptools/base/type_converter_templates.py
+++ b/preptools/base/type_converter_templates.py
@@ -1,9 +1,0 @@
-class ConstantKeys:
-    NAME = "name"
-    COUNTRY = "country"
-    CITY = "city"
-    EMAIL = 'email'
-    WEBSITE = 'website'
-    DETAILS = 'details'
-    P2P_ENDPOINT = 'p2pEndpoint'
-    IREP = "irep"

--- a/preptools/command/prep_info_command.py
+++ b/preptools/command/prep_info_command.py
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
 
 from ..core.prep import create_reader_by_args
 

--- a/preptools/command/prep_setting_command.py
+++ b/preptools/command/prep_setting_command.py
@@ -97,6 +97,7 @@ def _init_for_register_prep(sub_parser, common_parent_parser, tx_parent_parser):
         type=str,
         required=False,
         nargs="?",
+        dest="p2pEndpoint",
         help="Network info used for connecting among P-Rep nodes"
     )
 
@@ -266,6 +267,7 @@ def _init_for_set_prep(sub_parser, common_parent_parser, tx_parent_parser):
         type=str,
         required=False,
         nargs="?",
+        dest="p2pEndpoint",
         help="Network info used for connecting among P-Rep nodes"
     )
 

--- a/preptools/command/prep_setting_command.py
+++ b/preptools/command/prep_setting_command.py
@@ -17,12 +17,12 @@ import argparse
 import json
 import sys
 
-from preptools.utils.constants import fields_to_validate
-from preptools.exception import InvalidFormatException
 from preptools.core.prep import create_writer_by_args
+from preptools.exception import InvalidFormatException
+from preptools.utils.constants import fields_to_validate
 from preptools.utils.format_checker import (
     validate_prep_data,
-    validate_each_prep_data
+    validate_field_in_prep_data
 )
 
 
@@ -139,7 +139,7 @@ def _get_prep_dict_from_cli(params, set_prep: bool = False):
 
                 if len(cmd_input.strip()) > 0:
                     try:
-                        validate_each_prep_data(field, cmd_input)
+                        validate_field_in_prep_data(field, cmd_input)
                         params[field] = cmd_input
                         break
 
@@ -211,8 +211,6 @@ def _init_for_set_prep(sub_parser, common_parent_parser, tx_parent_parser):
         help="Activate interactive mode when prep fields are blank.",
         action='store_true'
     )
-
-
 
     parser.add_argument(
         "--name",

--- a/preptools/command/prep_setting_command.py
+++ b/preptools/command/prep_setting_command.py
@@ -101,7 +101,7 @@ def _init_for_register_prep(sub_parser, common_parent_parser, tx_parent_parser):
     )
 
     parser.add_argument(
-        "--prep",
+        "--prep-json",
         type=str,
         required=False,
         nargs="?",
@@ -113,7 +113,7 @@ def _init_for_register_prep(sub_parser, common_parent_parser, tx_parent_parser):
 
 def _register_prep(args) -> str:
 
-    if args.prep:
+    if args.prep_json:
         params = _get_prep_json(args, blank_able=True)
     else:
         params = dict()
@@ -156,7 +156,7 @@ def _get_prep_dict_from_cli(params, set_prep: bool = False):
 
 
 def _get_prep_json(args, blank_able: bool = False):
-    path = args.prep
+    path = args.prep_json
 
     with open(path) as register:
         params = json.load(register)
@@ -270,7 +270,7 @@ def _init_for_set_prep(sub_parser, common_parent_parser, tx_parent_parser):
     )
 
     parser.add_argument(
-        "--prep",
+        "--prep-json",
         type=str,
         required=False,
         help="json file having prepInfo"
@@ -281,7 +281,7 @@ def _init_for_set_prep(sub_parser, common_parent_parser, tx_parent_parser):
 
 def _set_prep(args) -> str:
 
-    if args.prep:
+    if args.prep_json:
         params = _get_prep_json(args, blank_able=True)
     else:
         params = dict()

--- a/preptools/command/prep_setting_command.py
+++ b/preptools/command/prep_setting_command.py
@@ -17,11 +17,12 @@ import argparse
 import json
 import sys
 
+from preptools.utils.constants import fields_to_validate
 from preptools.exception import InvalidFormatException
-
 from preptools.core.prep import create_writer_by_args
 from preptools.utils.format_checker import (
-    validate_prep_data
+    validate_prep_data,
+    validate_each_prep_data
 )
 
 
@@ -44,6 +45,62 @@ def _init_for_register_prep(sub_parser, common_parent_parser, tx_parent_parser):
         help=desc)
 
     parser.add_argument(
+        "--name",
+        type=str,
+        required=False,
+        nargs="?",
+        help="PRep name"
+    )
+
+    parser.add_argument(
+        "--country",
+        type=str,
+        required=False,
+        nargs="?",
+        help="P-Rep's country"
+    )
+
+    parser.add_argument(
+        "--city",
+        type=str,
+        required=False,
+        nargs="?",
+        help="P-Rep's city"
+    )
+
+    parser.add_argument(
+        "--email",
+        type=str,
+        required=False,
+        nargs="?",
+        help="P-Rep's email"
+    )
+
+    parser.add_argument(
+        "--website",
+        type=str,
+        required=False,
+        nargs="?",
+        help="P-Rep's homepage url"
+    )
+
+    parser.add_argument(
+        "--details",
+        type=str,
+        required=False,
+        nargs="?",
+        help="P-Rep off-chain details"
+    )
+
+    parser.add_argument(
+        "--p2p-endpoint",
+        type=str,
+        required=False,
+        nargs="?",
+        help="Network info used for connecting among P-Rep nodes"
+    )
+
+    parser.add_argument(
         "--prep",
         type=str,
         required=False,
@@ -56,10 +113,13 @@ def _init_for_register_prep(sub_parser, common_parent_parser, tx_parent_parser):
 
 def _register_prep(args) -> str:
 
-    if args.prep is not None:
-        params = _get_json(args.prep)
+    if args.prep:
+        params = _get_prep_json(args, blank_able=True)
     else:
-        params = _get_prep_info_from_cli()
+        params = dict()
+        _get_prep_input(args, params)
+
+    _get_prep_dict_from_cli(params)
 
     writer = create_writer_by_args(args)
     response = writer.register_prep(params)
@@ -67,58 +127,54 @@ def _register_prep(args) -> str:
     return response
 
 
-def _get_prep_dict_from_cli():
+def _get_prep_dict_from_cli(params, set_prep: bool = False):
 
-    prep_info = dict()
+    for field in fields_to_validate:
 
-    try:
-        prep_info['name'] = input('> name : ')
-        prep_info['country'] = input('> country : ')
-        prep_info['city'] = input('> city : ')
-        prep_info['email'] = input('> email : ')
-        prep_info['website'] = input('> website : ')
-        prep_info['details'] = input('> details : ')
-        prep_info['p2pEndpoint'] = input('> p2pEndpoint : ')
+        while True:
+            if params.get(field, None) is None:  # param is not found.
 
-    except InvalidFormatException as e:
-        print(e.args[0])
+                cmd_input = input(f" > {field} : ")
 
-    ret = dict()
+                if len(cmd_input.strip()) > 0:
+                    try:
+                        validate_each_prep_data(field, cmd_input)
+                        params[field] = cmd_input
+                        break
 
-    for k, v in prep_info.items():
-        if v is not '':
-            ret[k] = v
+                    except InvalidFormatException as e:
+                        print(e.args[0])
 
-    return ret
+                elif set_prep:  # in case of set_prep, don't have to get all params.
+                    break
 
+                else:
+                    print(f"please enter {field}.")
 
-def _get_prep_info_from_cli():
-
-    while True:
-
-        prep_info = _get_prep_dict_from_cli()
-
-        print(json.dumps(prep_info, indent=4))
-
-        check = input('All of them are right? (Y/n): ')
-
-        if check.lower() == 'y':
-            break
-
-    return prep_info
+            else:
+                break
 
 
-def _get_json(path, set_prep: bool = False):
+def _get_prep_json(args, blank_able: bool = False):
+    path = args.prep
+
     with open(path) as register:
         params = json.load(register)
+        _get_prep_input(args, params)
 
     try:
-        validate_prep_data(params, set_prep)
+        validate_prep_data(params, blank_able)
     except InvalidFormatException as e:
         print(e.args[0])
         sys.exit(1)  # invalid format entered.
 
     return params
+
+
+def _get_prep_input(args, params: dict):
+    for key in fields_to_validate:
+        if hasattr(args, key) and getattr(args, key) is not None:
+            params[key] = getattr(args, key)
 
 
 def _init_for_unregister_prep(sub_parser, common_parent_parser, tx_parent_parser):
@@ -150,6 +206,70 @@ def _init_for_set_prep(sub_parser, common_parent_parser, tx_parent_parser):
         help=desc)
 
     parser.add_argument(
+        "-i", "--interactive",
+        help="Activate interactive mode when prep fields are blank.",
+        action='store_true'
+    )
+
+
+
+    parser.add_argument(
+        "--name",
+        type=str,
+        required=False,
+        nargs="?",
+        help="PRep name"
+    )
+
+    parser.add_argument(
+        "--country",
+        type=str,
+        required=False,
+        nargs="?",
+        help="P-Rep's country"
+    )
+
+    parser.add_argument(
+        "--city",
+        type=str,
+        required=False,
+        nargs="?",
+        help="P-Rep's city"
+    )
+
+    parser.add_argument(
+        "--email",
+        type=str,
+        required=False,
+        nargs="?",
+        help="P-Rep's email"
+    )
+
+    parser.add_argument(
+        "--website",
+        type=str,
+        required=False,
+        nargs="?",
+        help="P-Rep's homepage url"
+    )
+
+    parser.add_argument(
+        "--details",
+        type=str,
+        required=False,
+        nargs="?",
+        help="P-Rep off-chain details"
+    )
+
+    parser.add_argument(
+        "--p2p-endpoint",
+        type=str,
+        required=False,
+        nargs="?",
+        help="Network info used for connecting among P-Rep nodes"
+    )
+
+    parser.add_argument(
         "--prep",
         type=str,
         required=False,
@@ -161,10 +281,14 @@ def _init_for_set_prep(sub_parser, common_parent_parser, tx_parent_parser):
 
 def _set_prep(args) -> str:
 
-    if args.prep is not None:
-        params = _get_json(args.prep,set_prep=True)
+    if args.prep:
+        params = _get_prep_json(args, blank_able=True)
     else:
-        params = _get_prep_info_from_cli(is_set_prep=True)
+        params = dict()
+        _get_prep_input(args, params)
+
+    if args.interactive:
+        _get_prep_dict_from_cli(params, set_prep=True)
 
     writer = create_writer_by_args(args)
     response = writer.set_prep(params)

--- a/preptools/command/tx_info_command.py
+++ b/preptools/command/tx_info_command.py
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
 
 from ..core.prep import create_reader_by_args
 

--- a/preptools/preptools_cli.py
+++ b/preptools/preptools_cli.py
@@ -51,7 +51,11 @@ def main():
 
     args = parser.parse_args()
 
-    response: Optional[dict, int] = args.func(args)
+    try:
+        response: Optional[dict, int] = args.func(args)
+    except KeyboardInterrupt:
+        print("\nexit")
+        sys.exit(0)
 
     if isinstance(response, dict):
         if 'result' in response:

--- a/preptools/utils/constants.py
+++ b/preptools/utils/constants.py
@@ -27,9 +27,26 @@ DEFAULT_NID = 3
 
 COLUMN = 80
 
-PREDEFINED_URLS = {
-    "mainnet": "https://ctz.solidwallet.io/api/v3",
-    "testnet": "https://test-ctz.solidwallet.io/api/v3",
-    "bicon": "https://bicon.net.solidwallet.io/api/v3",
-    "localhost": DEFAULT_URL
-}
+PREDEFINED_URLS = {}
+
+
+class ConstantKeys:
+    NAME = "name"
+    COUNTRY = "country"
+    CITY = "city"
+    EMAIL = 'email'
+    WEBSITE = 'website'
+    DETAILS = 'details'
+    P2P_ENDPOINT = 'p2pEndpoint'
+    IREP = "irep"
+
+
+fields_to_validate = (
+            ConstantKeys.NAME,
+            ConstantKeys.COUNTRY,
+            ConstantKeys.CITY,
+            ConstantKeys.EMAIL,
+            ConstantKeys.WEBSITE,
+            ConstantKeys.DETAILS,
+            ConstantKeys.P2P_ENDPOINT
+        )

--- a/preptools/utils/format_checker.py
+++ b/preptools/utils/format_checker.py
@@ -46,28 +46,28 @@ def validate_prep_data(data: dict, blank_able: bool = False):
         if len(data[key].strip()) < 1 and not blank_able:
             raise InvalidFormatException("Can not set empty data")
 
-        validate_each_prep_data(key, data[key])
+        validate_field_in_prep_data(key, data[key])
 
 
-def validate_each_prep_data(key: str, value: str):
+def validate_field_in_prep_data(key: str, value: str):
 
     if key == ConstantKeys.P2P_ENDPOINT:
-        _validate_p2p_endpoint(value)
+        validate_p2p_endpoint(value)
     elif key in (ConstantKeys.WEBSITE, ConstantKeys.DETAILS):
-        _validate_uri(value)
+        validate_uri(value)
     elif key == ConstantKeys.EMAIL:
-        _validate_email(value)
+        validate_email(value)
     elif key == ConstantKeys.COUNTRY:
-        _validate_country(value)
+        validate_country(value)
 
 
-def _validate_p2p_endpoint(p2p_endpoint: str):
+def validate_p2p_endpoint(p2p_endpoint: str):
     network_locate_info = p2p_endpoint.split(":")
 
     if len(network_locate_info) != 2:
         raise InvalidFormatException("Invalid endpoint format. endpoint must have port info")
 
-    _validate_port(network_locate_info[1], ConstantKeys.P2P_ENDPOINT)
+    validate_port(network_locate_info[1], ConstantKeys.P2P_ENDPOINT)
 
     if ENDPOINT_IP_PATTERN.match(p2p_endpoint):
         return
@@ -76,7 +76,7 @@ def _validate_p2p_endpoint(p2p_endpoint: str):
         raise InvalidFormatException("Invalid endpoint format")
 
 
-def _validate_uri(uri: str):
+def validate_uri(uri: str):
     uri = uri.lower()
     if WEBSITE_DOMAIN_NAME_PATTERN.match(uri):
         return
@@ -86,7 +86,7 @@ def _validate_uri(uri: str):
     raise InvalidFormatException("Invalid uri format")
 
 
-def _validate_port(port: str, validating_field: str):
+def validate_port(port: str, validating_field: str):
     try:
         port = int(port, 10)
     except ValueError:
@@ -96,11 +96,11 @@ def _validate_port(port: str, validating_field: str):
         raise InvalidFormatException(f"Invalid {validating_field} format. Port out of range: {port}")
 
 
-def _validate_email(email: str):
+def validate_email(email: str):
     if not EMAIL_PATTERN.match(email):
         raise InvalidFormatException("Invalid email format")
 
 
-def _validate_country(country_code: str):
+def validate_country(country_code: str):
     if country_code.upper() not in iso3166.countries_by_alpha3:
         raise InvalidFormatException("Invalid alpha-3 country code")

--- a/preptools/utils/format_checker.py
+++ b/preptools/utils/format_checker.py
@@ -18,7 +18,7 @@ import re
 import iso3166
 
 from preptools.exception import InvalidFormatException
-from ..base.type_converter_templates import ConstantKeys
+from preptools.utils.constants import fields_to_validate, ConstantKeys
 
 scheme_pattern = r'^(http:\/\/|https:\/\/)'
 path_pattern = r'(\/\S*)?$'
@@ -33,17 +33,8 @@ WEBSITE_IP_PATTERN = re.compile(f'{scheme_pattern}{ip_regex}{port_regex}{path_pa
 EMAIL_PATTERN = re.compile(email_regex)
 
 
-def validate_prep_data(data: dict, set_prep: bool = False):
-    if not set_prep:
-        fields_to_validate = (
-            ConstantKeys.NAME,
-            ConstantKeys.COUNTRY,
-            ConstantKeys.CITY,
-            ConstantKeys.EMAIL,
-            ConstantKeys.WEBSITE,
-            ConstantKeys.DETAILS,
-            ConstantKeys.P2P_ENDPOINT
-        )
+def validate_prep_data(data: dict, blank_able: bool = False):
+    if not blank_able:
 
         for key in fields_to_validate:
             if key not in data:
@@ -52,19 +43,22 @@ def validate_prep_data(data: dict, set_prep: bool = False):
                 raise InvalidFormatException("Can not set empty data")
 
     for key in data:
-        if set_prep:
-            if len(data[key].strip()) == 0:
-                continue
-        if len(data[key].strip()) < 1:
+        if len(data[key].strip()) < 1 and not blank_able:
             raise InvalidFormatException("Can not set empty data")
-        if key == ConstantKeys.P2P_ENDPOINT:
-            _validate_p2p_endpoint(data[key])
-        elif key in (ConstantKeys.WEBSITE, ConstantKeys.DETAILS):
-            _validate_uri(data[key])
-        elif key == ConstantKeys.EMAIL:
-            _validate_email(data[key])
-        elif key == ConstantKeys.COUNTRY:
-            _validate_country(data[key])
+
+        validate_each_prep_data(key, data[key])
+
+
+def validate_each_prep_data(key: str, value: str):
+
+    if key == ConstantKeys.P2P_ENDPOINT:
+        _validate_p2p_endpoint(value)
+    elif key in (ConstantKeys.WEBSITE, ConstantKeys.DETAILS):
+        _validate_uri(value)
+    elif key == ConstantKeys.EMAIL:
+        _validate_email(value)
+    elif key == ConstantKeys.COUNTRY:
+        _validate_country(value)
 
 
 def _validate_p2p_endpoint(p2p_endpoint: str):

--- a/preptools/utils/preptools_config.py
+++ b/preptools/utils/preptools_config.py
@@ -1,5 +1,4 @@
 from preptools.utils.constants import DEFAULT_URL, DEFAULT_NID
-from iconsdk.utils.convert_type import convert_int_to_hex_str
 
 preptools_config = {
     "url": DEFAULT_URL,

--- a/setup.py
+++ b/setup.py
@@ -6,20 +6,20 @@ with open('requirements.txt') as requirements:
     requires = list(requirements)
 
 setup_options = {
-    'name': 'core',
+    'name': 'preptools',
     'version': '0.0.1',
     'description': 'Test suite for ICON SCORE development',
     'author': 'ICON Foundation',
     'author_email': 'foo@icon.foundation',
     'packages': find_packages(exclude=['tests*', 'docs']),
     'include_package_data': True,
-    'py_modules': ['core'],
+    'py_modules': ['preptools'],
     'license': "Apache License 2.0",
     'install_requires': requires,
     'test_suite': 'tests',
     'entry_points': {
         'console_scripts': [
-            'core=core:main'
+            'preptools=preptools:main'
         ],
     },
     'classifiers': [

--- a/tests/test_command/test_prep_setting_command.py
+++ b/tests/test_command/test_prep_setting_command.py
@@ -18,18 +18,19 @@ import json
 import unittest
 
 from iconsdk.utils.convert_type import convert_hex_str_to_int
+
+from preptools.command.prep_setting_command import (
+    _register_prep,
+    _unregister_prep,
+    _set_prep,
+    _set_governance_variables
+)
 from tests.commons.constants import (
     TEST_KEYSTORE_PATH,
     TEST_KEYSTORE_PASSWORD,
     TEST_REGISTER_JSON_PATH,
     TEST_SET_JSON_PATH,
     TEST_CONFIG_PATH
-)
-from preptools.command.prep_setting_command import (
-    _register_prep,
-    _unregister_prep,
-    _set_prep,
-    _set_governance_variables
 )
 
 
@@ -50,6 +51,7 @@ class TestPRep(unittest.TestCase):
         self.args.keystore = TEST_KEYSTORE_PATH
         self.args.password = TEST_KEYSTORE_PASSWORD
         self.args.yes = True
+        self.args.interactive = False
 
     def test_register_prep(self):
         self.args.prep = TEST_REGISTER_JSON_PATH

--- a/tests/test_command/test_prep_setting_command.py
+++ b/tests/test_command/test_prep_setting_command.py
@@ -54,7 +54,7 @@ class TestPRep(unittest.TestCase):
         self.args.interactive = False
 
     def test_register_prep(self):
-        self.args.prep = TEST_REGISTER_JSON_PATH
+        self.args.prep_json = TEST_REGISTER_JSON_PATH
         response = _register_prep(self.args)
         print(response)
         self.assertFalse(response.get('error', False))
@@ -65,7 +65,7 @@ class TestPRep(unittest.TestCase):
         self.assertFalse(response.get('error', False))
 
     def test_set_prep(self):
-        self.args.prep = TEST_SET_JSON_PATH
+        self.args.prep_json = TEST_SET_JSON_PATH
         response = _set_prep(self.args)
         print(response)
         self.assertFalse(response.get('error', False))

--- a/tests/test_prep/test_prep.py
+++ b/tests/test_prep/test_prep.py
@@ -49,11 +49,8 @@ class TestPRep(unittest.TestCase):
         self.args.yes = True
 
     def test_register_prep(self):
-        wallet = KeyWallet.load(TEST_KEYSTORE_PATH, TEST_KEYSTORE_PASSWORD)
-
         with open(TEST_REGISTER_JSON_PATH) as register:
             params = json.load(register)
-        params['publicKey'] = convert_bytes_to_hex_str(wallet.bytes_public_key)
 
         writer = create_writer_by_args(self.args)
         response = writer.register_prep(params)

--- a/tests/test_utils/test_format_checker.py
+++ b/tests/test_utils/test_format_checker.py
@@ -19,10 +19,10 @@ import unittest
 
 from preptools.exception import InvalidFormatException
 from preptools.utils.format_checker import (
-    _validate_country,
-    _validate_email,
-    _validate_p2p_endpoint,
-    _validate_uri,
+    validate_country,
+    validate_email,
+    validate_p2p_endpoint,
+    validate_uri,
     validate_prep_data
 )
 from tests.commons.constants import TEST_SET_JSON_PATH, TEST_REGISTER_JSON_PATH, TEST_KEYSTORE_PATH
@@ -37,74 +37,74 @@ class TestFormatChecker(unittest.TestCase):
         # with valid param
         email = "iconproject@iconloop.com"
         try:
-            _validate_email(email)
+            validate_email(email)
         except InvalidFormatException as e:
             self.fail(e.args[0])
 
         # with invalid param
         email = "icon-project'@iconloop.com"
-        self.assertRaises(InvalidFormatException, _validate_email, email)
+        self.assertRaises(InvalidFormatException, validate_email, email)
 
         email = "icon-project@iconloop."
-        self.assertRaises(InvalidFormatException, _validate_email, email)
+        self.assertRaises(InvalidFormatException, validate_email, email)
 
     def test_check_url(self):
         # with valid param
         website = "http://www.naver.co.kr:9231/"
         try:
-            _validate_uri(website)
+            validate_uri(website)
         except InvalidFormatException as e:
             self.fail(e.args[0])
 
         website = "http://www.naver.co.kr:9231"
         try:
-            _validate_uri(website)
+            validate_uri(website)
         except InvalidFormatException as e:
             self.fail(e.args[0])
 
         # with valid param
         details = "http://www.naver.co.kr:9231/api/v3"
         try:
-            _validate_uri(details)
+            validate_uri(details)
         except InvalidFormatException as e:
             self.fail(e.args[0])
 
         # with invalid param
         details = "http://www.n,aver.co.kr:9231/api/v3"
-        self.assertRaises(InvalidFormatException, _validate_uri, details)
+        self.assertRaises(InvalidFormatException, validate_uri, details)
 
         details = "http://www.naver.co.kr:923,1/a|p|i/v3?asdfe\_#"
-        self.assertRaises(InvalidFormatException, _validate_uri, details)
+        self.assertRaises(InvalidFormatException, validate_uri, details)
 
     def test_check_country(self):
         # with valid param
         country = "KOR"
         try:
-            _validate_country(country)
+            validate_country(country)
         except InvalidFormatException as e:
             self.fail(e.args[0])
 
         # with invalid param
         country = "KOREA"
-        self.assertRaises(InvalidFormatException, _validate_country, country)
+        self.assertRaises(InvalidFormatException, validate_country, country)
 
     def test_check_p2pEndpoint(self):
         # with valid param
         p2p_endpoint = "127.0.0.1:9000"
         try:
-            _validate_p2p_endpoint(p2p_endpoint)
+            validate_p2p_endpoint(p2p_endpoint)
         except InvalidFormatException as e:
             self.fail(e.args[0])
 
         p2p_endpoint = "www.naver.co.kr:9231"
         try:
-            _validate_p2p_endpoint(p2p_endpoint)
+            validate_p2p_endpoint(p2p_endpoint)
         except InvalidFormatException as e:
             self.fail(e.args[0])
 
         # with invalid param
         p2p_endpoint = "http://www.naver.co.kr:9231"
-        self.assertRaises(InvalidFormatException, _validate_p2p_endpoint, p2p_endpoint)
+        self.assertRaises(InvalidFormatException, validate_p2p_endpoint, p2p_endpoint)
 
     def test_check_prep(self):
         # with set_prep.json file


### PR DESCRIPTION
1. Edit validation check when registerPRep, setPRep called. 
2. When registerPRep called, inputs are received all of json file, cmd line, interactive mode  
        1.  if registerPRep have --prep-json option, receive json file contents.
        2. if registerPRep have params (like name, city, ... etc), receive that contents.
        3. The missing contents in the above two are input in the interactive cli.
        4. The priority of the contents is input as cmd> json.
3. When setPRep called, interactive mode is executed when the -i option is input.