### PR TITLE
IS-1262: unrecognize steplimit option(bugfix)

### DIFF
--- a/preptools/command/prep_setting_command.py
+++ b/preptools/command/prep_setting_command.py
@@ -122,7 +122,7 @@ def _register_prep(args) -> str:
         params = _get_prep_json(args, blank_able=True)
 
     else:
-        params = dict()
+        params = {}
         _get_prep_input(args, params)
 
     _get_prep_dict_from_cli(params)
@@ -361,7 +361,7 @@ def create_tx_parser() -> argparse.ArgumentParser:
     )
 
     parent_parser.add_argument(
-        "--step-limit" "-s",
+        "--step-limit", "-s",
         type=str_to_int,
         required=False,
         dest="step_limit",

--- a/preptools/command/proposal_setting_command.py
+++ b/preptools/command/proposal_setting_command.py
@@ -235,7 +235,7 @@ def create_tx_parser() -> argparse.ArgumentParser:
     )
 
     parent_parser.add_argument(
-        "--step-limit" "-s",
+        "--step-limit", "-s",
         type=str_to_int,
         required=False,
         dest="step_limit",

--- a/preptools/core/prep.py
+++ b/preptools/core/prep.py
@@ -91,12 +91,12 @@ class PRepToolsWriter(PRepToolsListener):
         self._nid = nid
         self._step_limit = step_limit
 
-    def _call(self, method: str, params: dict, to: str = ZERO_ADDRESS, step_limit: int = 0x10000000, value: int = 0) -> dict:
+    def _call(self, method: str, params: dict, to: str = ZERO_ADDRESS, value: int = 0) -> dict:
         tx_handler = self._create_tx_handler()
         return tx_handler.call(
             owner=self._owner,
             to=to,
-            limit=step_limit,
+            limit=self._step_limit,
             method=method,
             params=params,
             value=value


### PR DESCRIPTION
Make preptools to recognize steplimit option
* pass initialized steplimit rather than default value of steplimit parameter
* fix parser