### PR TITLE
Allow for more special characters in email validation 

### DIFF
--- a/preptools/utils/validation_checker.py
+++ b/preptools/utils/validation_checker.py
@@ -25,7 +25,7 @@ path_pattern = r'(\/\S*)?$'
 port_regex = r'(:[0-9]{1,5})?'
 ip_regex = r'(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])'
 host_name_regex = r'(localhost|(?:[\w\d](?:[\w\d-]{0,61}[\w\d])\.)+[\w\d][\w\d-]{0,61}[\w\d])'
-email_regex = r'^[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*@' + host_name_regex + '$'
+email_regex = r'^[a-z0-9]+[\._|\-|\+]?[a-z0-9]+[@]\w+' + host_name_regex + '$'
 password_regex = r'^(?=.*\d)(?=.*[a-zA-Z])(?=.*[?!:\.,%+-/*<>{}\(\)\[\]`"\'~_^\\|@#$&]).{8,}$'
 ENDPOINT_DOMAIN_NAME_PATTERN = re.compile(f'^{host_name_regex}{port_regex}$')
 ENDPOINT_IP_PATTERN = re.compile(f'^{ip_regex}{port_regex}$')

--- a/tests/test_utils/test_format_checker.py
+++ b/tests/test_utils/test_format_checker.py
@@ -35,14 +35,22 @@ class TestFormatChecker(unittest.TestCase):
 
     def test_check_email_format(self):
         # with valid param
-        email = "iconproject@iconloop.com"
-        try:
-            validate_email(email)
-        except InvalidFormatException as e:
-            self.fail(e.args[0])
+        emails = ["iconproject@iconloop.com",
+                  "icon_project@iconloop.com",
+                  "icon-project@iconloop.com",
+                  "icon+project@iconloop.com"]
+        for email in emails:
+            try:
+                validate_email(email)
+            except InvalidFormatException as e:
+                self.fail(e.args[0])
 
         # with invalid param
         email = "icon-project'@iconloop.com"
+        self.assertRaises(InvalidFormatException, validate_email, email)
+
+        # with double hyphen
+        email = "icon--project@iconloop.com"
         self.assertRaises(InvalidFormatException, validate_email, email)
 
         email = "icon-project@iconloop."


### PR DESCRIPTION
Prior email validation regex didn't allow for any special characters.  This PR allows for `_`, `-`, and `+` characters consistent with email rules though is not the full [RFC 882](http://www.ex-parrot.com/~pdw/Mail-RFC822-Address.html). 